### PR TITLE
update: Predicted values for line graphs are now displayed as dotted lines

### DIFF
--- a/src/components/PrefectureCheckBoxes/PrefectureCheckBoxes.tsx
+++ b/src/components/PrefectureCheckBoxes/PrefectureCheckBoxes.tsx
@@ -22,6 +22,7 @@ const PrefectureCheckBoxes: FC<PrefectureCheckBoxesProps> = ({
                   type="checkbox"
                   name={prefecture.prefName}
                   onChange={handlePrefectureCheckbox}
+                  checked={prefecture.isChecked}
                 />
                 {prefecture.prefName}
               </label>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -99,6 +99,14 @@ const Home: FC = () => {
     setSelectedLabel(matchingLabel);
   };
 
+  const resetCheckBoxes = () => {
+    const updatedPrefectures = prefecturesWithCheck.map((prefecture) => ({
+      ...prefecture,
+      isChecked: false,
+    }));
+    setPrefecturesWithCheck(updatedPrefectures);
+  };
+
   const fetchPrefectures = async () => {
     const prefecturesEndpoint = '/api/v1/prefectures';
 
@@ -125,6 +133,8 @@ const Home: FC = () => {
         prefectures={prefecturesWithCheck}
         handlePrefectureCheckbox={handlePrefectureCheckbox}
       />
+
+      <button onClick={resetCheckBoxes}>全てのチェックを外す</button>
 
       <PopulationLabelSelector
         selectedLabel={selectedLabel}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -142,6 +142,7 @@ const Home: FC = () => {
       />
 
       <LineGraphComponent
+        boundaryYear={allPopulationData.boundaryYear}
         populationData={allPopulationData[selectedLabel]}
         prefecturesWithCheck={prefecturesWithCheck}
       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-interface PrefectureBase {
+type PrefectureBase = {
   prefCode: number;
   prefName: string;
-}
+};
 
 export type PrefecturesAPIResponse = {
   message: string | null;


### PR DESCRIPTION
## 内容
・すべてのチェックボックスを外すボタン追加
・boundaryYear（実測値）を境界に実線と点線になるように
・１つだけinterfaceで定義していた型をtypeに統一