### PR TITLE
refactor: PopulationLineGraph to use combinePopulationByYearData utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [2weeksフロントエンドサマーインターン](https://hrmos.co/pages/yumemi/jobs/12345678901234567894)に応募した際の選考の過程で取り組んだもの
 
-**総開発時間:**
+**総開発時間: 32時間**
 
 **頂いた評価:**
 
@@ -30,6 +30,6 @@ npm run dev
 
 ## デプロイ
 
-このアプリケーションは、GitHub Pagesにデプロイされています。
+このアプリケーションは、[Vercel](https://vercel.com/)にデプロイされています。
 デプロイされたWebサイトは、以下のURLから確認できます。
-<https://imoken777.github.io/yumemi-frontend-test/>
+<https://yumemi-frontend-test-gamma.vercel.app/>

--- a/src/components/LineGraphComponent/LineGraph.tsx
+++ b/src/components/LineGraphComponent/LineGraph.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { Fragment, useMemo } from 'react';
+import { Fragment } from 'react';
 import {
   CartesianGrid,
   Legend,
@@ -12,7 +12,11 @@ import {
 } from 'recharts';
 import type { AllPopulationData, PopulationData } from '../../types/PopulationTypes';
 import type { PrefectureWithCheck } from '../../types/PrefectureTypes';
-import { convertToJapaneseUnits, numberToColor } from '../../utils/graphCustom';
+import {
+  combinePopulationByYearData,
+  convertToJapaneseUnits,
+  numberToColor,
+} from '../../utils/graphCustom';
 
 type LineGraphProps = {
   boundaryYear: AllPopulationData['boundaryYear'];
@@ -25,28 +29,7 @@ const LineGraphComponent: FC<LineGraphProps> = ({
   populationData,
   prefecturesWithCheck: prefectures,
 }) => {
-  const combinedPopulationByYearData = useMemo(() => {
-    const yearMap: { [key: number]: { year: number; [key: string]: number | null } } = {};
-
-    populationData.forEach((popData) => {
-      popData.data.forEach((entry) => {
-        if (yearMap[entry.year] === undefined) {
-          yearMap[entry.year] = { year: entry.year };
-        }
-        yearMap[entry.year][popData.prefName] = entry.value;
-      });
-    });
-
-    Object.values(yearMap).forEach((yearData) => {
-      populationData.forEach((popData) => {
-        if (!(popData.prefName in yearData)) {
-          yearData[popData.prefName] = null;
-        }
-      });
-    });
-
-    return Object.values(yearMap);
-  }, [populationData]);
+  const combinedPopulationByYearData = combinePopulationByYearData(populationData);
 
   //グラフを見た目上連続にするため、boundaryYearのデータは重複して描画する
   const actualData = combinedPopulationByYearData.filter((d) => d.year <= boundaryYear);

--- a/src/components/PopulationLineGraph/PopulationLineGraph.tsx
+++ b/src/components/PopulationLineGraph/PopulationLineGraph.tsx
@@ -18,13 +18,13 @@ import {
   numberToColor,
 } from '../../utils/graphCustom';
 
-type LineGraphProps = {
+type PopulationLineGraphProps = {
   boundaryYear: AllPopulationData['boundaryYear'];
   populationData: PopulationData[];
   prefecturesWithCheck: PrefectureWithCheck[];
 };
 
-const LineGraphComponent: FC<LineGraphProps> = ({
+const PopulationLineGraph: FC<PopulationLineGraphProps> = ({
   boundaryYear: boundaryYear,
   populationData,
   prefecturesWithCheck: prefectures,
@@ -101,4 +101,4 @@ const LineGraphComponent: FC<LineGraphProps> = ({
   );
 };
 
-export default LineGraphComponent;
+export default PopulationLineGraph;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps, InferGetStaticPropsType } from 'next';
 import type { FC } from 'react';
-import LineGraphComponent from '../components/LineGraphComponent/LineGraph';
 import PopulationLabelSelector from '../components/PopulationLabelSelector/PopulationLabelSelector';
+import PopulationLineGraph from '../components/PopulationLineGraph/PopulationLineGraph';
 import PrefectureCheckBoxes from '../components/PrefectureCheckBoxes/PrefectureCheckBoxes';
 import { usePopulationData } from '../hooks/usePopulationData';
 import { usePopulationLabel } from '../hooks/usePopulationLabel';
@@ -50,7 +50,7 @@ const Home: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         </section>
 
         <section className={styles.graphSection}>
-          <LineGraphComponent
+          <PopulationLineGraph
             boundaryYear={allPopulationData.boundaryYear}
             populationData={allPopulationData[selectedLabel]}
             prefecturesWithCheck={prefecturesWithCheck}

--- a/src/testsPages/pages/index.test.tsx
+++ b/src/testsPages/pages/index.test.tsx
@@ -5,7 +5,7 @@ import { usePopulationLabel } from '../../hooks/usePopulationLabel';
 import { usePrefectureCheck } from '../../hooks/usePrefectureCheck';
 import Home from '../../pages/index';
 
-jest.mock('../../components/LineGraphComponent/LineGraph', () => {
+jest.mock('../../components/PopulationLineGraph/PopulationLineGraph', () => {
   const LineGraphComponent = () => <div>LineGraphComponent</div>;
   LineGraphComponent.displayName = 'LineGraphComponent';
   return LineGraphComponent;

--- a/src/utils/graphCustom.ts
+++ b/src/utils/graphCustom.ts
@@ -1,3 +1,28 @@
+import type { PopulationData } from '../types/PopulationTypes';
+
+export const combinePopulationByYearData = (populationData: PopulationData[]) => {
+  const yearMap: { [key: number]: { year: number; [key: string]: number | null } } = {};
+
+  populationData.forEach((popData) => {
+    popData.data.forEach((entry) => {
+      if (yearMap[entry.year] === undefined) {
+        yearMap[entry.year] = { year: entry.year };
+      }
+      yearMap[entry.year][popData.prefName] = entry.value;
+    });
+  });
+
+  Object.values(yearMap).forEach((yearData) => {
+    populationData.forEach((popData) => {
+      if (!(popData.prefName in yearData)) {
+        yearData[popData.prefName] = null;
+      }
+    });
+  });
+
+  return Object.values(yearMap);
+};
+
 export const numberToColor = (number: number) => {
   const colors = [
     '#ff0000',

--- a/src/utils/tests/graphCustom.test.ts
+++ b/src/utils/tests/graphCustom.test.ts
@@ -1,4 +1,64 @@
-import { convertToJapaneseUnits, numberToColor } from '../graphCustom';
+import type { PopulationData } from '../../types/PopulationTypes';
+import { combinePopulationByYearData, convertToJapaneseUnits, numberToColor } from '../graphCustom';
+
+describe('combinePopulationByYearData', () => {
+  test('should combine population data by year correctly', () => {
+    const populationData: PopulationData[] = [
+      {
+        prefName: '北海道',
+        prefCode: 1,
+        data: [
+          { year: 2000, value: 5600000 },
+          { year: 2005, value: 5500000 },
+        ],
+      },
+      {
+        prefName: '青森県',
+        prefCode: 2,
+        data: [
+          { year: 2000, value: 1400000 },
+          { year: 2005, value: 1350000 },
+        ],
+      },
+    ];
+
+    const expected = [
+      { year: 2000, 北海道: 5600000, 青森県: 1400000 },
+      { year: 2005, 北海道: 5500000, 青森県: 1350000 },
+    ];
+
+    const result = combinePopulationByYearData(populationData);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should handle missing years for some prefectures', () => {
+    const populationData: PopulationData[] = [
+      {
+        prefName: '北海道',
+        prefCode: 1,
+        data: [{ year: 2000, value: 5600000 }],
+      },
+      {
+        prefName: '青森県',
+        prefCode: 2,
+        data: [
+          { year: 2000, value: 1400000 },
+          { year: 2005, value: 1350000 },
+        ],
+      },
+    ];
+
+    const expected = [
+      { year: 2000, 北海道: 5600000, 青森県: 1400000 },
+      { year: 2005, 北海道: null, 青森県: 1350000 },
+    ];
+
+    const result = combinePopulationByYearData(populationData);
+
+    expect(result).toEqual(expected);
+  });
+});
 
 describe('graphCustom', () => {
   describe('numberToColor', () => {


### PR DESCRIPTION
## 内容
・ combinePopulationByYearDataを関数としてutlis/に移動
・その関数のテストコード追加
・PopulationLineGraphに名前変更
・README.mdに総開発時間とデプロイ先を記載